### PR TITLE
Feature/document rule overrides in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,22 @@ module.exports = {
 };
 ```
 
+The custom rule `prefer-destucturing` also supports the configuration `object` and `array` and takes a boolean value. This allows disabling a subset of the rule, if desired.
+
+```js
+// .eslintrc.js
+
+module.exports = {
+  // ...
+  rules: {
+    'ember-suave/prefer-destucturing': ['error', {
+      array: false,
+      object: true
+    }]
+  }
+};
+```
+
 ## Working with Editors and the CLI
 
 If you use ESLint in an editor or from the command line, you'll need to install `eslint-plugin-ember-suave` globally too.

--- a/tests/fixtures/disallow-newline-before-block-statements/good/for.js
+++ b/tests/fixtures/disallow-newline-before-block-statements/good/for.js
@@ -1,3 +1,3 @@
-for (let e in elements) {
-  bar(e);
+if (cond) {
+  foo();
 }

--- a/tests/fixtures/disallow-newline-before-block-statements/good/for.js
+++ b/tests/fixtures/disallow-newline-before-block-statements/good/for.js
@@ -1,3 +1,3 @@
-if (cond) {
-  foo();
+for (let e in elements) {
+  bar(e);
 }


### PR DESCRIPTION
It took a little digging to find [this commit](https://github.com/DockYard/eslint-plugin-ember-suave/commit/7b41ebb841f857b4b7a8133cb3da412d76e5f1be), so I added documentation of the params you can pass to this rule to the README. We didn't want array destructuring, but we wanted most everything else