### PR TITLE
Add func-call-spacing, remove no-spaced-func

### DIFF
--- a/config/base.js
+++ b/config/base.js
@@ -28,7 +28,7 @@ module.exports = {
     'new-cap': ['error'],
     'no-empty': ['error'],
     'no-multiple-empty-lines': ['error', { 'max': 1 }],
-    'no-spaced-func': 'error',
+    'func-call-spacing': 'error',
     'no-trailing-spaces': 'error',
     'no-useless-concat': 'error',
     'object-curly-spacing': ['error', 'always'],


### PR DESCRIPTION
The [`no-spaced-func`](http://eslint.org/docs/rules/no-spaced-func) rule was [deprecated](https://github.com/eslint/eslint/pull/6749) in eslint 3.3.0 and replaced by the [`func-call-spacing`](http://eslint.org/docs/rules/func-call-spacing) rule.