### PR TITLE
Implement an exception option for require-const-for-ember-properties

### DIFF
--- a/lib/rules/require-const-for-ember-properties.js
+++ b/lib/rules/require-const-for-ember-properties.js
@@ -6,15 +6,42 @@
 
 var MESSAGE = 'Always use `const` when making variables from Ember properties';
 
+// Given a node, returns the dot accessor.
+function sourceExpression(node) {
+  if (node.type === 'VariableDeclarator') {
+    return sourceExpression(node.init);
+  }
+
+  if (node.type === 'MemberExpression') {
+    return sourceExpression(node.object) + '.' + sourceExpression(node.property);
+  }
+
+  if (node.type === 'Identifier') {
+    return node.name;
+  }
+
+  return '';
+}
+
 module.exports = {
   meta: {
-    schema: []
+    schema: {
+      exceptions: {
+        type: 'array',
+        items: {
+          type: 'string'
+        }
+      }
+    }
   },
   create: function(context) {
     function checkVariableDeclaration(node) {
       var declaration = node.declarations[0];
+      var exceptions = (context.options[0] && context.options[0].exceptions) || [];
 
-      if (hasEmberIdentifier(declaration) && node.kind !== 'const') {
+      if (hasEmberIdentifier(declaration)
+        && node.kind !== 'const'
+        && exceptions.indexOf(sourceExpression(declaration)) === -1) {
         context.report({ node: node, message: MESSAGE });
       }
     }

--- a/tests/lib/rules/require-const-for-ember-properties.js
+++ b/tests/lib/rules/require-const-for-ember-properties.js
@@ -13,7 +13,9 @@ ruleTester.run('require-const-for-ember-properties', rule, {
     { code: 'const { foo } = Ember;', parserOptions: { ecmaVersion: 6 } },
     { code: 'const foo = Ember.foo;', parserOptions: { ecmaVersion: 6 } },
     // Verify that we don't break declaring a variable without assignment
-    { code: 'var foo;', parserOptions: { ecmaVersion: 6 } }
+    { code: 'var foo;', parserOptions: { ecmaVersion: 6 } },
+    { code: 'var foo = Ember.foo;', options: [{ exceptions: ['Ember.foo'] }] },
+    { code: 'var schedule = Ember.run.schedule;', options: [{ exceptions: ['Ember.run.schedule'] }] }
   ],
   invalid: [
     {


### PR DESCRIPTION
Adding an option lets the user to avoid the linter for
certain exceptional accessors.

Not sure we need to actually resolve the conflict between the rules
as Ember has moved to an import based system.

Fixes #31