### PR TITLE
Fix test.

### DIFF
--- a/tests/fixtures/require-spread/bad/example.js
+++ b/tests/fixtures/require-spread/bad/example.js
@@ -1,3 +1,5 @@
 const wrap = (f, g) => {
-  return (...args) => g.apply(g, [f].concat(args));
-}
+  return (...args) => g.apply(null, [f].concat(args));
+};
+
+wrap(1, (a) => a + 2);


### PR DESCRIPTION
`g.apply(g, [f].concat(args))` is changing the context of the function
as `g` is just being called as such. This change does make it fail
because of the unneeded call.