### PR TITLE
Add no-await-in-loop rule

### DIFF
--- a/config/recommended.js
+++ b/config/recommended.js
@@ -18,6 +18,7 @@ module.exports = {
       'before': false,
       'after': true
     }],
+    'no-await-in-loop': 'error',
     'no-var': 'error',
     'no-return-await': 'error',
     'no-useless-rename': 'error',

--- a/tests/fixtures/no-await-in-loop/bad/example.js
+++ b/tests/fixtures/no-await-in-loop/bad/example.js
@@ -1,0 +1,11 @@
+async function badLooping(promises) {
+  let newArray = [];
+
+  for (let i = 0; i < promises.length; i++) {
+    newArray.push(await promises[i]);
+  }
+
+  return newArray;
+}
+
+badLooping([]);

--- a/tests/fixtures/no-await-in-loop/good/example.js
+++ b/tests/fixtures/no-await-in-loop/good/example.js
@@ -1,0 +1,7 @@
+async function goodLooping(promises) {
+  let results = await Promise.all(promises);
+
+  return results;
+}
+
+goodLooping([]);


### PR DESCRIPTION
This prevent users from `await`ing promises inside a loop.

There are cases where an `await` inside the loop are needed, but IMHO are rare.