### PR TITLE
Remove sort-imports rule

### DIFF
--- a/config/recommended.js
+++ b/config/recommended.js
@@ -38,7 +38,6 @@ module.exports = {
     'prefer-destructuring': ['error', { array: false, object: true }, { enforceForRenamedProperties: false }],
     'prefer-spread': 'error',
     'prefer-template': 'error',
-    'sort-imports': 'error',
 
     'import/no-relative-parent-imports': 'error',
 

--- a/tests/fixtures/sort-imports/bad/imported-order.js
+++ b/tests/fixtures/sort-imports/bad/imported-order.js
@@ -1,3 +1,0 @@
-import { b, a, z } from 'a';
-
-b(a, z);

--- a/tests/fixtures/sort-imports/bad/source-order.js
+++ b/tests/fixtures/sort-imports/bad/source-order.js
@@ -1,5 +1,0 @@
-import b from 'b';
-import a from 'a';
-
-a(b, c);
-

--- a/tests/fixtures/sort-imports/good/good.js
+++ b/tests/fixtures/sort-imports/good/good.js
@@ -1,5 +1,0 @@
-import { a, b, c } from 'first';
-import { s, z } from 'second';
-
-// Just use them
-a(b(c), s(z));


### PR DESCRIPTION
Error messages are not clear enough and, even knowing what needs to be
done, sometimes it was hard to fix.